### PR TITLE
Fix conflicting malloc

### DIFF
--- a/xmalloc.c
+++ b/xmalloc.c
@@ -6,8 +6,8 @@
 #include <curses.h>
 #include "sc.h"
 
-extern char	*malloc();
-extern char	*realloc();
+/*extern char	*malloc();*/
+/*extern char	*realloc();*/
 extern void	free();
 void		fatal();
 


### PR DESCRIPTION
Comment out malloc and realloc extern prototypes in `xmalloc.c`, so it can compile correctly on a modern Linux distribution. Tested on Debian 7 (64 bits) and Ubuntu 14.04 (64 bits).
